### PR TITLE
Fix vagrant issue: use exact version of bundler (#1355)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,7 @@ Vagrant.configure(2) do |config|
       echo "=============================================="
       echo "Installing app dependencies"
       cd /vagrant
+      sudo gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)" 
       bundle config build.nokogiri --use-system-libraries
       bundle install
     SHELL


### PR DESCRIPTION
I was getting this error, ''Cant find gem bundler (>= 0.a) with
executable bundle', after I ran `vagrant up`. The version of RubyGem
installed in the vagrant box cannot find the exact version of Bundler
listed in Gemfile.lock. This solution ensures that the exact bundler
version installed in Gemfile.lock is installed before running `bundle
install`.

The issue is solved in RubyGems >= 2.7.10 and Ruby >=2.6.3. This
solution ensures a fix without requiring a more complicated upgrade.

More information found here: https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->